### PR TITLE
Fix contact section comment spacing

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -322,7 +322,7 @@ params:
         #  - icon: fab fa-github
         #    url: https://github.com/gurusabarish/HugoProfileV2
 
-  #Contact
+  # Contact
   contact:
     enable: false
     # title: "Custom Name"


### PR DESCRIPTION
## Summary
- fix spacing for `# Contact` section heading

## Testing
- `pre-commit` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841ccae23048327ab62981db0059fa7